### PR TITLE
Fix Docker build failure: Add missing frontend public directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,7 @@ dist
 
 # Gatsby files
 .cache/
-public
+# public (commented out to allow React frontend/public directory)
 
 # Storybook build outputs
 .out

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="description" content="Web crawler search interface" />
+    <title>Web Crawler Search</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
Fixes Docker compose build failure caused by missing React app public directory structure.

## Issue
- Docker build was failing with error: `failed to calculate checksum of ref: '/public': not found`
- Frontend Dockerfile expected standard React app structure with `public/` directory
- Build process requires `public/index.html` as the HTML template for the SPA

## Root Cause
- Repository was missing the `frontend/public/` folder and required `index.html` template file
- `.gitignore` had a blanket `public` ignore rule (from Gatsby template) that was blocking React public directories
- React build process (`react-scripts build`) requires the public directory structure

## Solution
- Updated `.gitignore` to allow `frontend/public` directory (commented out blanket 'public' ignore)
- Created missing `frontend/public/index.html` with proper React app boilerplate
- Includes standard meta tags, viewport settings, and root div for React mounting
- Maintains compatibility with `react-scripts` build process

## Test Results
- ✅ Docker build now completes successfully
- ✅ Generates production-ready frontend bundle (69.18 kB gzipped)
- ✅ No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)